### PR TITLE
Add informational page for Dodobot bot

### DIFF
--- a/public/bot.html
+++ b/public/bot.html
@@ -1,0 +1,23 @@
+<!doctype html>
+<html lang="ru">
+<head>
+  <meta charset="utf-8"/>
+  <meta name="viewport" content="width=device-width,initial-scale=1"/>
+  <title>О боте Dodobot</title>
+  <link rel="stylesheet" href="style.css"/>
+</head>
+<body>
+  <div class="wrap">
+    <h1>О боте Dodobot</h1>
+    <p>Dodobot — ваш маленький помощник в Telegram. Он помогает находить ответы, напоминать о делах и просто делает общение удобнее.</p>
+    <h2>Возможности</h2>
+    <ul>
+      <li>Отвечает на частые вопросы</li>
+      <li>Напоминает о важных задачах</li>
+      <li>Работает круглосуточно</li>
+    </ul>
+    <p>Попробуйте сами: <a href="https://t.me/dodobot" target="_blank" rel="noopener noreferrer">запустить бота в Telegram</a>.</p>
+    <p><a href="index.html">← На главную</a></p>
+  </div>
+</body>
+</html>

--- a/public/index.html
+++ b/public/index.html
@@ -11,6 +11,7 @@
     <h1>Dodobot</h1>
     <p>Dodobot — простой Telegram-бот-помощник.</p>
     <p><a href="https://t.me/dodobot" target="_blank" rel="noopener noreferrer">Открыть бота в Telegram</a></p>
+    <p><a href="bot.html">Подробнее о боте</a></p>
   </div>
 </body>
 </html>

--- a/public/style.css
+++ b/public/style.css
@@ -1,4 +1,4 @@
-body { font-family: system-ui, sans-serif; margin:0; padding:40px; line-height:1.5; }
-.wrap { max-width:800px; margin:0 auto; }
+body { font-family: system-ui, sans-serif; margin:0; padding:40px; line-height:1.5; background:linear-gradient(120deg,#fdfbfb 0%,#ebedee 100%); color:#333; }
+.wrap { max-width:800px; margin:0 auto; background:#fff; padding:20px; border-radius:8px; box-shadow:0 2px 8px rgba(0,0,0,0.1); }
 a { color:#0077cc; text-decoration:none; }
 a:hover { text-decoration:underline; }


### PR DESCRIPTION
## Summary
- add detailed Telegram bot info page
- link main page to new page
- enhance styling with background and card layout

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68bf656ea9ec83339b7e2ee186ce08d0