### PR TITLE
Handle token errors and avoid duplicate redirect

### DIFF
--- a/pages/api/callback.js
+++ b/pages/api/callback.js
@@ -48,7 +48,20 @@ export default async function handler(req, res) {
     const serverResponse = await response.json();
     console.log("📨 Ответ от server.py:", serverResponse);
 
-    return res.status(200).json({ message: "Код успешно передан в server.py!" });
+    if (!response.ok || serverResponse.error || serverResponse.success === false) {
+      console.error("❌ Ошибка от server.py:", serverResponse);
+      return res.status(500).json({
+        success: false,
+        message:
+          serverResponse.message || "Не удалось получить токены от server.py",
+      });
+    }
+
+    return res.status(200).json({
+      success: true,
+      message:
+        serverResponse.message || "Код успешно передан и токены получены",
+    });
 
   } catch (error) {
     console.error("❌ Ошибка обработки запроса:", error);

--- a/pages/callback.js
+++ b/pages/callback.js
@@ -89,14 +89,12 @@ export default function Callback() {
             setDetails(`Код ответа сервера: ${resp.status}`);
             lastErr = new Error(`HTTP ${resp.status}`);
           } else {
-            const okByMessage =
-              resp.data && (resp.data.success === true || resp.data.message?.includes("успеш"));
-            if (okByMessage) {
+            const success = resp.data && resp.data.success === true;
+            if (success) {
               setStatus(STATUS.OK);
-              const { deep, web } = buildTelegramLink({ botUser, startParam: start });
+              const { deep } = buildTelegramLink({ botUser, startParam: start });
               setTimeout(() => {
                 window.location.href = deep;
-                setTimeout(() => (window.location.href = web), 600);
               }, autoRedirectMs);
             } else {
               setStatus(STATUS.FAIL);


### PR DESCRIPTION
## Summary
- Propagate token fetch failures from server.py and return success status
- Only mark authorization successful when backend confirms
- Remove secondary fallback redirect to t.me to avoid duplicate page

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build` *(fails: next not found)*
- `npm install` *(fails: 403 Forbidden fetching next)*

------
https://chatgpt.com/codex/tasks/task_e_68c00f330b3c83338177d739b0619305